### PR TITLE
U/R works for fresh charts!

### DIFF
--- a/global.gd
+++ b/global.gd
@@ -37,9 +37,9 @@ var changes := [[Note,[]]] #The nested array which stores all created notes and 
 
 var revision = 0 #number of revisions made to chart since TODO: program start (should be since LOAD; need to reset variables on load)
 
-var d_note : Note # note to be removed by del/r-click/m-click
+var d_note : Note #note to be removed by del/r-click/m-click
 var deleted = false #was a note deleted? if so, run chart.filicide(note) upon reaching update_note_array(), then continue updating the note
-var please_come_back = false #If I remove a child, the note will run _exit_tree(), so I have to redirect the program back to update_note_array()
+var please_come_back = false #if I remove a child, the note will run _exit_tree(), so I have to redirect the program back to update_note_array()
 
 var ratio := ["L","L","L","L","L"] #data injected into a_array on deletion, d_array on addition, and d_array first on move
 var respects := ["F","F","F","F","F"] #data injected into a_array second on move

--- a/global.gd
+++ b/global.gd
@@ -42,9 +42,9 @@ var initial_size = 0
 
 var a_array := []
 var d_array := []
-var main_stack := []
+var active_stack := []
 
-var changes := {}
+var changes := [[Note,[]]]
 var key_name #TODO for multi-note editing: : String = revision number + _ + action ([a]dd,[d]elete, or [m]ove
 var d_note : Note
 

--- a/global.gd
+++ b/global.gd
@@ -23,35 +23,32 @@ func beat_to_time(beat:float) -> float: return beat / (working_tmb.tempo / 60.0)
 func time_to_beat(time:float) -> float: return time * (60.0 / working_tmb.tempo)
 
 ### Dew's variables ###
+
 var UR := [0,0,0]
 	# 0   => normal operation
 	# 1   => undo last action
 	# 2   => redo last action
 	#  ,0 => run no calculations //with addition of UR[2], should never be reached beyond initial declarations
-	#  ,1 => run A/D calculations only
-	#  ,2 => run any calculation
+	#  ,1 => run A/D calculations only (one step forward/backward in history)
+	#  ,2 => run any calculation (one to two steps forward/backward in history)
 	#  ,, => available redos
-var starting_note : Array
-var old_note : Note
 
-var ratio := ["L","L","L","L","L"]
-var respects := ["F","F","F","F","F"]
-var revision = 0
-var chart_just_loaded : bool
-var initial_size = 0
+var changes := [[Note,[]]] #The nested array which stores all created notes and their data at time of revision, traversed by Global.revision
 
-var a_array := []
-var d_array := []
-var active_stack := []
+var revision = 0 #number of revisions made to chart since TODO: program start (should be since LOAD; need to reset variables on load)
 
-var changes := [[Note,[]]]
-var key_name #TODO for multi-note editing: : String = revision number + _ + action ([a]dd,[d]elete, or [m]ove
-var d_note : Note
+var d_note : Note # note to be removed by del/r-click/m-click
+var deleted = false #was a note deleted? if so, run chart.filicide(note) upon reaching update_note_array(), then continue updating the note
+var please_come_back = false #If I remove a child, the note will run _exit_tree(), so I have to redirect the program back to update_note_array()
 
-var please_come_back = false
-var deleted = false
+var ratio := ["L","L","L","L","L"] #data injected into a_array on deletion, d_array on addition, and d_array first on move
+var respects := ["F","F","F","F","F"] #data injected into a_array second on move
+var loaded := ["3","3","3","3","3"] #TODO: data injected into d_array for loaded notes
 
-var fresh := true
+var a_array := [] #list of added notes, separated by ratios and respects, denoting deletions and moves in the history, respectively
+var d_array := [] #list of deleted notes, separated by ratios denoting added notes in the history
+var active_stack := [] #list of notes in tmb.notes, ordered by which revision it was added/edited during
+
 ### Dew's variables ###
 
 # shamelessly copied from wikiped https://en.wikipedia.org/wiki/Smoothstep#Variations

--- a/global.gd
+++ b/global.gd
@@ -21,7 +21,8 @@ const NUM_KEYS = 27
 var settings : Settings
 func beat_to_time(beat:float) -> float: return beat / (working_tmb.tempo / 60.0)
 func time_to_beat(time:float) -> float: return time * (60.0 / working_tmb.tempo)
-###Dew's variables###
+
+### Dew's variables ###
 var UR := [0,0,0]
 	# 0   => normal operation
 	# 1   => undo last action
@@ -31,6 +32,8 @@ var UR := [0,0,0]
 	#  ,2 => run any calculation
 	#  ,, => available redos
 var starting_note : Array
+var old_note : Note
+
 var ratio := ["L","L","L","L","L"]
 var respects := ["F","F","F","F","F"]
 var revision = 0
@@ -40,6 +43,15 @@ var initial_size = 0
 var a_array := []
 var d_array := []
 var main_stack := []
+
+var changes := {}
+var key_name #TODO for multi-note editing: : String = revision number + _ + action ([a]dd,[d]elete, or [m]ove
+var d_note : Note
+
+var please_come_back = false
+var deleted = false
+### Dew's variables ###
+
 # shamelessly copied from wikiped https://en.wikipedia.org/wiki/Smoothstep#Variations
 static func smootherstep(from:float, to:float, x:float) -> float:
 	x = clamp((x - from) / (to - from), 0.0, 1.0)

--- a/global.gd
+++ b/global.gd
@@ -50,6 +50,8 @@ var d_note : Note
 
 var please_come_back = false
 var deleted = false
+
+var fresh := true
 ### Dew's variables ###
 
 # shamelessly copied from wikiped https://en.wikipedia.org/wiki/Smoothstep#Variations

--- a/main.gd
+++ b/main.gd
@@ -110,6 +110,11 @@ func _on_load_dialog_file_selected(path:String) -> void:
 	%WavePreview.clear_wave_preview()
 	var dir = saveload.on_load_dialog_file_selected(path)
 	%TrackPlayer.stream = null
+	
+	###Dew size check
+	Global.initial_size = 0
+	###
+	
 	emit_signal("chart_loaded")
 	var err = try_to_load_stream(dir)
 	if err: print("No stream loaded -- %s" % error_string(err))

--- a/main.gd
+++ b/main.gd
@@ -110,11 +110,6 @@ func _on_load_dialog_file_selected(path:String) -> void:
 	%WavePreview.clear_wave_preview()
 	var dir = saveload.on_load_dialog_file_selected(path)
 	%TrackPlayer.stream = null
-	
-	###Dew size check
-	Global.initial_size = 0
-	###
-	
 	emit_signal("chart_loaded")
 	var err = try_to_load_stream(dir)
 	if err: print("No stream loaded -- %s" % error_string(err))

--- a/pianoroll/chart.gd
+++ b/pianoroll/chart.gd
@@ -211,10 +211,10 @@ func _on_tmb_loaded():
 
 func stuff_note(note := [Note,[]]) :
 	stuffing = true
-	print(stuffing)
-	stuffed_note = note[0][0]
+	print(note)
+	stuffed_note = note[0]
 	print("stuffed_note: ", stuffed_note)
-	add_note(false, note[0][1][0], note[0][1][1], note[0][1][2], note[0][1][3])
+	add_note(false, note[1][0], note[1][1], note[1][2], note[1][3])
 	return
 
 func add_note(start_drag:bool, bar:float, length:float, pitch:float, pitch_delta:float = 0.0):
@@ -328,14 +328,15 @@ func UR_handler():
 		print("UR Undo! // [1]: ",Global.UR[1])
 		if Global.revision > 1:
 			if Global.a_array[Global.revision-2] == Global.respects :
+				print(Global.revision-1,"pre(changes) ",Global.changes[Global.revision-1])
 				drag_UR = true
 				print("undo dragged")
 				passed_note = Global.d_array[Global.revision-2]
 				print("revision: ", Global.revision)
-				
-				for note in Global.changes[Global.revision-2] :
-					stuff_note([note])
-				print("a_stack changes note u_m: ",Global.a_array[Global.revision-1]," = ",Global.changes[Global.revision-2])
+				#print("note(s) @ rev-2: ", Global.changes[Global.revision-2])
+				for note in Global.changes[Global.revision-1] :
+					stuff_note(note)
+				#print("a_stack changes note u_m: ",Global.a_array[Global.revision-1]," = ",Global.changes[Global.revision-2])
 				Global.active_stack.remove_at(Global.active_stack.bsearch(Global.a_array[Global.revision-1]))
 				Global.active_stack.append(passed_note)
 				
@@ -345,10 +346,8 @@ func UR_handler():
 		if !drag_UR :
 			if Global.d_array[Global.revision-1] == Global.ratio:
 				print("undo added")
-				for note in Global.changes[Global.revision] :
-					print(Global.changes[Global.revision])
-					filicide(note[0])
-				print("a_stack changes note u_a: ",Global.a_array[Global.revision-1]," = ",Global.changes[Global.revision-1])
+				filicide(Global.changes[Global.revision][-1][0])
+				#print("a_stack changes note u_a: ",Global.a_array[Global.revision-1]," = ",Global.changes[Global.revision-1])
 				Global.active_stack.remove_at(Global.active_stack.bsearch(Global.a_array[Global.revision-1]))
 				Global.revision -= 1
 				Global.UR[0] = 0
@@ -361,7 +360,7 @@ func UR_handler():
 				passed_note = Global.d_array[Global.revision-1]
 				
 				for note in Global.changes[Global.revision-1] :
-					stuff_note([note])
+					stuff_note(note)
 				
 				Global.revision -= 1
 				Global.UR[0] = 0
@@ -376,14 +375,15 @@ func UR_handler():
 		print("UR Redo! // [1]: ",Global.UR[1])
 		if Global.UR[1] == 2 :
 			if Global.a_array[Global.revision] == Global.respects :
+				print(Global.revision+2,"pre(changes) ",Global.changes[Global.revision+2])
 				drag_UR = true
 				print("redo dragged")
 				passed_note = Global.a_array[Global.revision+1]
 				print("revision: ", Global.revision)
 				
-				for note in Global.changes[Global.revision+1] :
-					stuff_note([note])
-				print("a_stack changes note r_m: ",Global.a_array[Global.revision-1]," = ",Global.changes[Global.revision-1])
+				for note in Global.changes[Global.revision+	2] :
+					stuff_note(note)
+				#print("a_stack changes note r_m: ",Global.a_array[Global.revision-1]," = ",Global.changes[Global.revision-1])
 				Global.active_stack.remove_at(Global.active_stack.bsearch(Global.d_array[Global.revision]))
 				Global.active_stack.append(passed_note)
 				
@@ -398,7 +398,7 @@ func UR_handler():
 				passed_note = Global.a_array[Global.revision]
 				
 				for note in Global.changes[Global.revision+1] :
-					stuff_note([note])
+					stuff_note(note)
 				
 				Global.active_stack.append(passed_note)
 				
@@ -407,9 +407,8 @@ func UR_handler():
 		
 			elif Global.a_array[Global.revision] == Global.ratio :
 				print("redo deleted")
-				for note in Global.changes[Global.revision]:
-					filicide(note[0])
-				print("a_stack changes note r_d: ",Global.a_array[Global.revision-1])
+				filicide(Global.changes[Global.revision][-1][0])
+				#print("a_stack changes note r_d: ",Global.a_array[Global.revision-1])
 				Global.active_stack.remove_at(Global.active_stack.bsearch(Global.d_array[Global.revision]))
 				Global.revision += 1
 				Global.UR[2] -= 1

--- a/pianoroll/chart.gd
+++ b/pianoroll/chart.gd
@@ -56,6 +56,7 @@ var dumb_copy := []
 var short_stack = 0
 var stuffing := false
 var stuffed_note : Note
+var drag_UR := false
 ###
 
 var EDIT_MODE := 0
@@ -101,13 +102,15 @@ func filicide(child):
 
 #Dew remove future undo/redo chain when overwritten
 func redo_check():
-	print("revision: ", Global.revision)
+	print("rev changes: ", Global.revision)
 	if Global.UR[2] > 0 :
-		var excess = Global.changes.keys()
-		for note in excess.slice(Global.revision+1,excess.size()-1,1,true) :
-			Global.changes.erase(note)
+		print("pre changes: ",Global.changes)
+		Global.changes = Global.changes.slice(0,Global.revision+1,1,true)
+		print("redo changes: ",Global.changes)
 		Global.a_array = Global.a_array.slice(0,Global.revision,1,true)
 		Global.d_array = Global.d_array.slice(0,Global.revision,1,true)
+		
+		
 		Global.UR[2] = 0
 	return
 	###
@@ -116,15 +119,15 @@ func redo_check():
 func _unhandled_key_input(event):
 	var shift = event as InputEventWithModifiers
 	if !shift.shift_pressed && Input.is_action_just_pressed("ui_undo") && Global.revision > 0:
-		short_stack = Global.a_array.size() + Global.initial_size - Global.main_stack.size()
+		short_stack = Global.a_array.size() + Global.initial_size - Global.active_stack.size()
 		Global.UR[0] = 1
-		print("undo!")
+		print("undo pressed!")
 		update_note_array()
 	if Input.is_action_just_pressed("ui_redo") && Global.UR[2] > 0:
 		Global.UR[0] = 2
 		Global.UR[1] = 2
-		short_stack = Global.a_array.size() + Global.initial_size - Global.main_stack.size()
-		print("redo!")
+		short_stack = Global.a_array.size() + Global.initial_size - Global.active_stack.size()
+		print("redo pressed!")
 		if short_stack == 1 :
 			Global.UR[1] = 1
 		update_note_array()
@@ -206,18 +209,18 @@ func _on_tmb_loaded():
 	doot_enabled = %DootToggle.button_pressed
 	_on_tmb_updated()
 
-func stuff_note(note_data : Array, child_note : Note) :
+func stuff_note(note := [Note,[]]) :
 	stuffing = true
-	stuffed_note = child_note
+	print(stuffing)
+	stuffed_note = note[0][0]
 	print("stuffed_note: ", stuffed_note)
-	"hi"
-	add_note(false, note_data[0], note_data[1], note_data[2], note_data[3])
+	add_note(false, note[0][1][0], note[0][1][1], note[0][1][2], note[0][1][3])
 	return
 
 func add_note(start_drag:bool, bar:float, length:float, pitch:float, pitch_delta:float = 0.0):
 	var new_note : Note
 	if !stuffing :
-		redo_check()
+		#redo_check()
 		new_note = note_scn.instantiate()
 	else:
 		stuffing = false
@@ -265,12 +268,12 @@ func update_note_array():
 			note.pitch_start + note.pitch_delta
 		]
 		new_array.append(note_array)
-		Global.main_stack = new_array
+		Global.active_stack = new_array
 	
 	print("added notes: ",Global.a_array)
 	print("deleted notes: ",Global.d_array)
-	print("Global.main_stack: ",Global.main_stack)
-	print("Global.changes: ",Global.changes)
+	#print("Global.active_stack: ",Global.active_stack)
+	#print("Global.changes: ",Global.changes)
 	
 	new_array.sort_custom(func(a,b): return a[TMBInfo.NOTE_BAR] < b[TMBInfo.NOTE_BAR])
 	tmb.notes = new_array
@@ -320,32 +323,33 @@ func assign_tt_note_ids():
 func UR_handler():
 	print("UR!!!",Global.UR[0])
 	var passed_note = []
-	var changed_note : Note
-	var drag_UR = false
+	drag_UR = false
 	if Global.UR[0] == 1 :
 		print("UR Undo! // [1]: ",Global.UR[1])
 		if Global.revision > 1:
 			if Global.a_array[Global.revision-2] == Global.respects :
+				drag_UR = true
 				print("undo dragged")
 				passed_note = Global.d_array[Global.revision-2]
-				changed_note = Global.changes.get(Global.revision)
 				print("revision: ", Global.revision)
-				print("change: ", changed_note)
-				stuff_note(passed_note, changed_note)
 				
-				Global.main_stack.remove_at(Global.main_stack.bsearch(Global.a_array[Global.revision-1]))
-				Global.main_stack.append(passed_note)
+				for note in Global.changes[Global.revision-2] :
+					stuff_note([note])
+				print("a_stack changes note u_m: ",Global.a_array[Global.revision-1]," = ",Global.changes[Global.revision-2])
+				Global.active_stack.remove_at(Global.active_stack.bsearch(Global.a_array[Global.revision-1]))
+				Global.active_stack.append(passed_note)
 				
 				Global.revision -= 2
 				Global.UR[0] = 0
 				Global.UR[2] += 1
-				drag_UR = true
 		if !drag_UR :
 			if Global.d_array[Global.revision-1] == Global.ratio:
 				print("undo added")
-				filicide(Global.changes.get(Global.revision))
-				
-				Global.main_stack.remove_at(Global.main_stack.bsearch(Global.a_array[Global.revision-1]))
+				for note in Global.changes[Global.revision] :
+					print(Global.changes[Global.revision])
+					filicide(note[0])
+				print("a_stack changes note u_a: ",Global.a_array[Global.revision-1]," = ",Global.changes[Global.revision-1])
+				Global.active_stack.remove_at(Global.active_stack.bsearch(Global.a_array[Global.revision-1]))
 				Global.revision -= 1
 				Global.UR[0] = 0
 				Global.UR[2] += 1
@@ -353,17 +357,18 @@ func UR_handler():
 			elif Global.a_array[Global.revision-1] == Global.ratio:
 				print("undo deleted: ", Global.changes)
 				print("revision: ",   Global.revision)
-				print("to be added: ",Global.changes.get(Global.revision))
+				print("to be added: ",Global.changes[Global.revision])
 				passed_note = Global.d_array[Global.revision-1]
 				
-				stuff_note(passed_note,Global.changes.get(Global.revision))
+				for note in Global.changes[Global.revision-1] :
+					stuff_note([note])
 				
 				Global.revision -= 1
 				Global.UR[0] = 0
 				Global.UR[2] += 1
 		
-		print("main_stack: ",Global.main_stack)
-		dumb_copy = Global.main_stack
+		print("active_stack: ",Global.active_stack)
+		dumb_copy = Global.active_stack
 		dumb_copy.sort_custom(func(a,b): return a[TMBInfo.NOTE_BAR] < b[TMBInfo.NOTE_BAR])
 		tmb.notes = dumb_copy
 		
@@ -371,50 +376,52 @@ func UR_handler():
 		print("UR Redo! // [1]: ",Global.UR[1])
 		if Global.UR[1] == 2 :
 			if Global.a_array[Global.revision] == Global.respects :
+				drag_UR = true
 				print("redo dragged")
 				passed_note = Global.a_array[Global.revision+1]
-				changed_note = Global.changes.get(Global.revision)
 				print("revision: ", Global.revision)
-				print("change: ", changed_note)
-				stuff_note(passed_note, changed_note)
 				
-				Global.main_stack.remove_at(Global.main_stack.bsearch(Global.d_array[Global.revision]))
-				Global.main_stack.append(passed_note)
+				for note in Global.changes[Global.revision+1] :
+					stuff_note([note])
+				print("a_stack changes note r_m: ",Global.a_array[Global.revision-1]," = ",Global.changes[Global.revision-1])
+				Global.active_stack.remove_at(Global.active_stack.bsearch(Global.d_array[Global.revision]))
+				Global.active_stack.append(passed_note)
 				
 				Global.revision += 2
 				Global.UR[2] -= 1
-				drag_UR = true
 			
 		if Global.UR[1] != 0 && !drag_UR :
 			if Global.d_array[Global.revision] == Global.ratio :
 				print("redo added: ", Global.changes)
 				print("revision: ",   Global.revision+1)
-				print("to be added: ",Global.changes.get(Global.revision+1))
+				print("to be added: ",Global.changes[Global.revision+1])
 				passed_note = Global.a_array[Global.revision]
 				
-				stuff_note(passed_note,Global.changes.get(Global.revision+1))
+				for note in Global.changes[Global.revision+1] :
+					stuff_note([note])
 				
-				Global.main_stack.append(passed_note)
+				Global.active_stack.append(passed_note)
 				
 				Global.revision += 1
 				Global.UR[2] -= 1
 		
 			elif Global.a_array[Global.revision] == Global.ratio :
 				print("redo deleted")
-				filicide(Global.changes.get(Global.revision))
-				
-				
-				Global.main_stack.remove_at(Global.main_stack.bsearch(Global.d_array[Global.revision]))
+				for note in Global.changes[Global.revision]:
+					filicide(note[0])
+				print("a_stack changes note r_d: ",Global.a_array[Global.revision-1])
+				Global.active_stack.remove_at(Global.active_stack.bsearch(Global.d_array[Global.revision]))
 				Global.revision += 1
 				Global.UR[2] -= 1
 				
-
+		
+		print("active_stack: ",Global.active_stack)
 		Global.UR[1] = 0
-		dumb_copy = Global.main_stack.slice(0,Global.revision)
+		dumb_copy = Global.active_stack.slice(0,Global.revision)
 		dumb_copy.sort_custom(func(a,b): return a[TMBInfo.NOTE_BAR] < b[TMBInfo.NOTE_BAR])
 		tmb.notes = dumb_copy
 	print("revision post-UR: ",Global.revision)
-	print("Global.main_stack: ",Global.main_stack)
+	print("Global.active_stack: ",Global.active_stack)
 	print("Global.changes: ",Global.changes)
 	
 	Global.UR[0] = 0


### PR DESCRIPTION
Does:
-use note.gd to read and store all note data, and use chart.gd to parse and edit all note data. [NICE]
-propagate undone drags to connected notes. [NICE]
-propagate undone drags to tmb_notes. [NICE]
-fully function as an undo/redo system for a fresh chart. **[NICE]**

Does not:
-register clicked notes when left unedited. [INTENDED]
-register clicked notes (which preexisted in a loaded chart) to history log as they are edited. [UNINTENDED]
-reset history upon loading any chart. [I need a better understanding of the order in which scripts and objects are loaded.]