### PR TITLE
Undo/Redo

### DIFF
--- a/copy_confirm.gd
+++ b/copy_confirm.gd
@@ -33,7 +33,7 @@ func _on_copy_confirmed():
 	Global.pasting = true
 	Global.pasted_selection = []
 	for note in Global.copy_data:
-		%Chart.add_note(false,note[0]+target,note[1],note[2],note[3],true)
+		%Chart.add_note(false,note[0]+target,note[1],note[2],note[3])
 	Global.pasting = false
 	
 	Global.clear_future_edits()

--- a/global.gd
+++ b/global.gd
@@ -32,6 +32,7 @@ var revision_format = [
 	"DRAGGED SET: [*[reference_1, [list of 1's old data], [list of 1's new data]]*(, *[reference_n, [list of n's old data], [list of n's new data]]*)]",
 	"PASTED SET: [*[overwritten_reference_1(, overwritten_reference_n)]*, *[pasted_reference_1(, pasted_reference_n)]*] (array of overwrittens can be empty)"
 ]
+var in_ur := false
 
 var fresh := false  #only true for notes that have been ADDED BY HAND and is set to false as soon as the note is added to timeline.
 func clear_future_edits(wipe := false):

--- a/global.gd
+++ b/global.gd
@@ -25,6 +25,13 @@ func time_to_beat(time:float) -> float: return time * (60.0 / working_tmb.tempo)
 ###Dew's globals###
 var revision = -1 	#unedited chart
 var actions = []	#0 = add, 1 = delete, 2 = dragged, 3 = paste
+enum {
+	ACTION_ADD,
+	ACTION_DELETE,
+	ACTION_DRAG,
+	ACTION_PASTE,
+	ACTION_NONE = -1,
+}
 var changes = []	#current timeline of past and future revisions in order; see below
 var revision_format = [
 	"ADD: [*[reference, old bar value]*]",

--- a/main.gd
+++ b/main.gd
@@ -76,18 +76,11 @@ func _input(event):
 				Alert.LV_SUCCESS)
 	#if event.pressed && event.keycode == KEY_C:
 		#print(%Chart.count_onscreen_notes()," notes being drawn")
-	#if event.pressed && event.keycode == KEY_I:
-		#for note in %Chart.get_children():
-			#if !(note is Note): continue
-			#print(note.bar," \t→ ",note.index_in_slide)
 
 
 func _on_description_text_changed(): tmb.description = %Description.text
-
 func _on_refresh_button_pressed(): emit_signal("chart_loaded")
-
 func _on_help_button_pressed(): show_popup($Instructions)
-
 func _on_ffmpeg_help_pressed(): show_popup($FFmpegInstructions)
 
 

--- a/main.gd
+++ b/main.gd
@@ -54,7 +54,7 @@ func _input(event):
 	if (		(get_viewport().gui_get_focus_owner() is TextEdit)
 			||  (get_viewport().gui_get_focus_owner() is LineEdit)):
 		return
-	if event.keycode == KEY_SHIFT:
+	if event.keycode == KEY_SHIFT && !%PlayheadHandle.dragging:
 		if event.pressed:
 			%Chart.show_preview = true
 		else:

--- a/main.gd
+++ b/main.gd
@@ -51,8 +51,8 @@ func _input(event):
 		_on_save_chart_pressed()
 	# If editing text, ignore shortcuts besides Ctrl+(Shift)+S
 	# note that, even typing into numerical SpinBoxes, you're using its own child LineEdit
-	if (		(get_viewport().gui_get_focus_owner() is TextEdit)
-			||  (get_viewport().gui_get_focus_owner() is LineEdit)):
+	if ((get_viewport().gui_get_focus_owner() is TextEdit)
+	||  (get_viewport().gui_get_focus_owner() is LineEdit)):
 		return
 	if event.keycode == KEY_SHIFT && !%PlayheadHandle.dragging:
 		if event.pressed:
@@ -66,11 +66,11 @@ func _input(event):
 		_on_paste()
 	if event.pressed && event.is_action_pressed("toggle_playback"):
 		%PreviewController._do_preview()
-	if event.is_action("select_mode") && !Input.is_key_pressed(KEY_CTRL):
+	if event.is_action("select_mode") && !Input.is_key_pressed(KEY_CTRL) && !Input.get_mouse_button_mask():
 		%Chart.mouse_mode = %Chart.SELECT_MODE
 		$Alert.alert("Switched mouse to Select Mode", Vector2(%ChartView.global_position.x, 10),
 				Alert.LV_SUCCESS)
-	if event.is_action("edit_mode") && !Input.is_key_pressed(KEY_CTRL):
+	if event.is_action("edit_mode") && !Input.is_key_pressed(KEY_CTRL) && !Input.get_mouse_button_mask():
 		%Chart.mouse_mode = %Chart.EDIT_MODE
 		$Alert.alert("Switched mouse to Edit Mode", Vector2(%ChartView.global_position.x, 10),
 				Alert.LV_SUCCESS)

--- a/note/drag_helper.gd
+++ b/note/drag_helper.gd
@@ -13,7 +13,9 @@ var drag_start := Vector2.ZERO
 var settings := Global.settings
 
 
-func _init(caller:Note): owner = caller
+func _init(caller:Note):
+	owner = caller
+	init_drag()
 
 
 func init_drag():

--- a/note/drag_helper.gd
+++ b/note/drag_helper.gd
@@ -26,7 +26,7 @@ func init_drag():
 	drag_start = owner.get_local_mouse_position()
 
 
-func process_drag(drag_type=Note.DRAG_NONE):
+func process_drag(drag_type=Note.DRAG_NONE): # -> float|Vector2|null
 	match drag_type:
 		Note.DRAG_BAR:
 			var new_time : float

--- a/note/note.gd
+++ b/note/note.gd
@@ -261,11 +261,7 @@ func _snap_near_pitches(): slide_helper.snap_near_pitches()
 
 
 func has_slide_neighbor(direction:int,pitch:float):
-	match direction:
-		START_IS_TOUCHING:
-			return touching_notes.has(direction) && touching_notes[direction].end_pitch == pitch
-		END_IS_TOUCHING:
-			return touching_notes.has(direction) && touching_notes[direction].pitch_start == pitch
+	return slide_helper.has_slide_neighbor(direction,pitch)
 
 
 func update_touching_notes():

--- a/note/note.gd
+++ b/note/note.gd
@@ -23,7 +23,7 @@ var pitch_start : float:
 		_update()
 var pitch_delta : float:
 	set(value):
-		if value != pitch_delta && doot_enabled:
+		if value != pitch_delta && doot_enabled && !Global.in_ur:
 			chart.doot(pitch_start + value)
 		pitch_delta = value
 		_update()

--- a/note/note.gd
+++ b/note/note.gd
@@ -97,8 +97,11 @@ var note_data : Array     #Data of the note targeted by the note_reference sette
 var note_reference: Note: #A nice and tidy concatenator for a note ref's data.
 	set(note_ref):
 		note_reference = note_ref
-		note_data = [note_ref.bar,note_ref.length,note_ref.pitch_start,note_ref.pitch_delta,note_ref.pitch_start+note_ref.pitch_delta]
+		note_data = note_ref.as_array()
 ###Dew variables###
+
+func as_array() -> Array: ## in the format that is stored in TMBs
+	return [ bar, length, pitch_start, pitch_delta, pitch_start+pitch_delta ]
 
 
 func update_slide_idx() -> int:

--- a/note/slide_helper.gd
+++ b/note/slide_helper.gd
@@ -23,9 +23,9 @@ func snap_near_pitches():
 
 
 func handle_slide_propagation(from:int):
+	var neighbor = touching_notes[from]
 	match from:
 		Note.START_IS_TOUCHING:
-			var neighbor = touching_notes[from]
 			var length_change = owner.bar - neighbor.end
 			var pitch_change = owner.pitch_start - neighbor.end_pitch
 			owner.bar -= length_change
@@ -33,7 +33,6 @@ func handle_slide_propagation(from:int):
 			owner.pitch_start -= pitch_change
 			owner.pitch_delta += pitch_change
 		Note.END_IS_TOUCHING:
-			var neighbor = touching_notes[from]
 			var length_change = owner.end - neighbor.bar
 			var pitch_change = owner.end_pitch - neighbor.pitch_start
 			owner.length -= length_change
@@ -92,11 +91,11 @@ func update_touching_notes():
 
 
 func pass_on_slide_propagation():
-		if has_slide_neighbor(Note.START_IS_TOUCHING, owner.drag_helper.old_pitch):
-			touching_notes[Note.START_IS_TOUCHING].receive_slide_propagation(Note.END_IS_TOUCHING)
-		
-		if has_slide_neighbor(Note.END_IS_TOUCHING, owner.drag_helper.old_end_pitch):
-			touching_notes[Note.END_IS_TOUCHING].receive_slide_propagation(Note.START_IS_TOUCHING)
+	if has_slide_neighbor(Note.START_IS_TOUCHING, owner.drag_helper.old_pitch):
+		touching_notes[Note.START_IS_TOUCHING].receive_slide_propagation(Note.END_IS_TOUCHING)
+	
+	if has_slide_neighbor(Note.END_IS_TOUCHING, owner.drag_helper.old_end_pitch):
+		touching_notes[Note.END_IS_TOUCHING].receive_slide_propagation(Note.START_IS_TOUCHING)
 
 
 func has_slide_neighbor(direction:int,pitch:float):

--- a/note/slide_helper.gd
+++ b/note/slide_helper.gd
@@ -44,10 +44,10 @@ func find_touching_notes() -> Dictionary:
 	var result := {}
 	
 	var prev_note = get_matching_note_off(owner.bar,[owner])
-	if prev_note: result[Note.START_IS_TOUCHING] = prev_note
+	if prev_note && chart.is_ancestor_of(owner): result[Note.START_IS_TOUCHING] = prev_note # be polite and don't trick your friend
 	
 	var next_note = get_matching_note_on(owner.end,[owner])
-	if next_note: result[Note.END_IS_TOUCHING] = next_note
+	if next_note && chart.is_ancestor_of(owner): result[Note.END_IS_TOUCHING] = next_note # ||
 	
 	return result
 
@@ -83,11 +83,12 @@ func update_touching_notes():
 		null: if old_next_note != null: old_next_note.update_touching_notes()
 		_: 
 			next_note.touching_notes[Note.START_IS_TOUCHING] = owner if owner.bar >= 0 \
+			&& chart.is_ancestor_of(owner) && chart.is_ancestor_of(next_note) \
 					else null
 			next_note.bar = owner.end
 			next_note.update_handle_visibility()
 	
-	owner.propagate_to_the_right("find_idx_in_slide",[])
+	owner.propagate_to_the_right("update_slide_idx",[])
 
 
 func pass_on_slide_propagation():

--- a/pianoroll/chart.gd
+++ b/pianoroll/chart.gd
@@ -317,6 +317,7 @@ func update_note_array():
 		new_array.append(note_array)
 	new_array.sort_custom(func(a,b): return a[TMBInfo.NOTE_BAR] < b[TMBInfo.NOTE_BAR])
 	tmb.notes = new_array
+	settings.ensure_valid_endpoint()
 	queue_redraw()
 	redraw_notes()
 

--- a/pianoroll/chart.gd
+++ b/pianoroll/chart.gd
@@ -265,6 +265,8 @@ func add_note(start_drag:bool, bar:float, length:float, pitch:float, pitch_delta
 	note.position.y = pitch_to_height(pitch)
 	note.dragging = Note.DRAG_INITIAL if start_drag else Note.DRAG_NONE
 	if doot_enabled && !Global.in_ur && !Global.pasting: doot(pitch)
+	if Global.in_ur && settings.length.value < tmb.get_last_note_off():
+		settings.length.value = max(2,ceilf(tmb.get_last_note_off()))
 	if act == -1: add_child(note) #Dew: We don't want to re-add the child to the parent if the data was only changed via drag; it's still on-screen.
 	else: return
 	note.grab_focus()

--- a/pianoroll/chart.gd
+++ b/pianoroll/chart.gd
@@ -294,11 +294,11 @@ func update_note_array():
 	var new_array := []
 	###Dew timeline tracker
 	var i := -1
-	print("Hi, I'm Tom Scott, and today I'm in func update_note_array()")
+	#print("Hi, I'm Tom Scott, and today I'm in func update_note_array()")
 	print("action timeline: ",Global.actions)
-	for change in Global.changes:
-		i += 1
-		print(i,": ",change)
+	#for change in Global.changes:
+		#i += 1
+		#print(i,": ",change)
 	print("terminal revision: ",Global.revision)
 	###
 	for note in get_children():

--- a/pianoroll/chart.gd
+++ b/pianoroll/chart.gd
@@ -422,7 +422,8 @@ func count_onscreen_notes() -> int:
 	return accum
 
 func update_playhead(event):
-	var bar = %Chart.x_to_bar(event.position.x)
+	var bar = x_to_bar(event.position.x)
+	if settings.snap_time: bar = snapped(bar,current_subdiv)
 	if event is InputEventMouseButton:
 		if event.button_index == MOUSE_BUTTON_LEFT:
 			if event.pressed:
@@ -460,7 +461,7 @@ func _gui_input(event):
 			var bar = %Chart.x_to_bar(event.position.x)
 			if bar < 0:
 				bar = 0
-			if settings.snap_time: bar = snapped(bar, %Chart.current_subdiv)
+			if settings.snap_time: bar = snapped(bar, current_subdiv)
 			if event is InputEventMouseButton && event.button_index == MOUSE_BUTTON_LEFT && event.pressed:
 				prev_section_start = bar
 				settings.section_start = bar
@@ -518,8 +519,7 @@ func _on_mouse_exited():
 	show_preview = false
 	queue_redraw()
 
-
-func _on_mouse_entered():
-	if Input.is_key_pressed(KEY_SHIFT):
-		show_preview = true
-		queue_redraw()
+#func _on_mouse_entered():
+	#if Input.is_key_pressed(KEY_SHIFT):
+		#show_preview = true
+		#queue_redraw()

--- a/pianoroll/chart.gd
+++ b/pianoroll/chart.gd
@@ -343,22 +343,20 @@ func assign_tt_note_ids():
 func _draw():
 	var font : Font = ThemeDB.get_fallback_font()
 	if tmb == null: return
-	if settings.section_length:
-		var section_rect = Rect2(bar_to_x(settings.section_start), 1,
-				bar_to_x(settings.section_length), size.y)
-		draw_rect(section_rect, Color(0.3, 0.9, 1.0, 0.1))
-		draw_rect(section_rect, Color.CORNFLOWER_BLUE, false, 3.0)
-	if show_preview:
-		var mouse_pos = get_local_mouse_position()
-		if get_rect().has_point(mouse_pos):
-			draw_line(Vector2(mouse_pos.x,0), Vector2(mouse_pos.x,size.y),
-						Color.ORANGE_RED, 1 )
-		# no way to change the delay on a per-node basis, it seems
-		ProjectSettings.set_setting('gui/timers/tooltip_delay_sec', 0)
-		tooltip_text = ("%.4f" % %Chart.x_to_bar(mouse_pos.x)).rstrip('0.')
-	else:
-		ProjectSettings.set_setting('gui/timers/tooltip_delay_sec', 0.5)
-		tooltip_text = ""
+	var section_rect = Rect2(bar_to_x(settings.section_start), 1,
+			bar_to_x(settings.section_length), size.y)
+	draw_rect(section_rect, Color(0.3, 0.9, 1.0, 0.1))
+	draw_rect(section_rect, Color.CORNFLOWER_BLUE, false, 3.0)
+	var rect_bumps_pos = Vector2(section_rect.position.x+0.5,size.y/2+3)
+	draw_line(rect_bumps_pos+Vector2(-5,-5),
+			rect_bumps_pos+Vector2(0,-5),Color.CORNFLOWER_BLUE,3.0)
+	draw_line(rect_bumps_pos+Vector2(-5,5),
+			rect_bumps_pos+Vector2(0,5),Color.CORNFLOWER_BLUE,3.0)
+	rect_bumps_pos.x += section_rect.size.x
+	draw_line(rect_bumps_pos+Vector2(0,-5),
+			rect_bumps_pos+Vector2(4,-5),Color.CORNFLOWER_BLUE,3.0)
+	draw_line(rect_bumps_pos+Vector2(0,5),
+			rect_bumps_pos+Vector2(4,5),Color.CORNFLOWER_BLUE,3.0)
 	if %PreviewController.is_playing:
 		if settings.section_length:
 			draw_line(Vector2(bar_to_x(%PreviewController.song_position),0),
@@ -366,6 +364,7 @@ func _draw():
 					Color.CORNFLOWER_BLUE, 2 )
 		else:
 			settings.playhead_pos = %PreviewController.song_position
+	# Draw bar lines
 	for i in tmb.endpoint + 1:
 		var line_x = i * bar_spacing
 		var next_line_x = (i + 1) * bar_spacing
@@ -391,9 +390,29 @@ func _draw():
 					str(i / tmb.timesig), HORIZONTAL_ALIGNMENT_LEFT, -1, 16)
 			draw_string(font, Vector2(i * bar_spacing, 0) + Vector2(8, 32),
 					str(i), HORIZONTAL_ALIGNMENT_LEFT, -1, 12)
-		draw_line(Vector2(bar_to_x(%PlayheadPos.value), 0),
-				Vector2(bar_to_x(%PlayheadPos.value), size.y),
-				Color.ORANGE_RED, 2.0)
+	# End drawing bar lines
+	if show_preview:
+		var mouse_pos = get_local_mouse_position()
+		if get_rect().has_point(mouse_pos):
+			draw_line(Vector2(mouse_pos.x,0), Vector2(mouse_pos.x,size.y),
+						Color.ORANGE_RED, 1 )
+		# no way to change the delay on a per-node basis, it seems
+		ProjectSettings.set_setting('gui/timers/tooltip_delay_sec', 0)
+		tooltip_text = ("%.4f" % x_to_bar(mouse_pos.x)).rstrip('0.')
+	else:
+		ProjectSettings.set_setting('gui/timers/tooltip_delay_sec', 0.5)
+		tooltip_text = ""
+	var playhead_pos = Vector2(bar_to_x(%PlayheadPos.value),0)
+	draw_line(playhead_pos,
+			playhead_pos + Vector2.DOWN*size.y,
+			Color.ORANGE_RED, 2.0)
+	if !%PreviewController.is_playing:
+		var play_symbol_size := 10
+		var play_symbol := [ playhead_pos,
+							playhead_pos+Vector2(play_symbol_size/1.33,play_symbol_size/2),
+							playhead_pos+Vector2(0,play_symbol_size) ]
+		draw_colored_polygon(play_symbol, Color.ORANGE_RED)
+		draw_polyline(play_symbol, Color.ORANGE_RED,0.5,true)
 
 
 func count_onscreen_notes() -> int:

--- a/pianoroll/chart.gd
+++ b/pianoroll/chart.gd
@@ -123,6 +123,7 @@ func _shortcut_input(event):
 
 ##Dew's favorite child :)
 func ur_handler():
+	Global.in_ur = true
 	print("UR entered with action: ", action,"!") #[add, del, drag, paste]
 	print("Global.revision: ", Global.revision," which acts on revision #: ", rev)
 	print("Selected data:", Global.changes[rev])
@@ -145,12 +146,12 @@ func ur_handler():
 				for note in Global.changes[rev]:
 					print("UR dragging (undo)!")
 					stuffed_note = note[REF]
-					add_note(false, note[OLD][0], note[OLD][1], note[OLD][2], note[OLD][3], true)
+					add_note(false, note[OLD][0], note[OLD][1], note[OLD][2], note[OLD][3])
 			else:		#redo
 				for note in Global.changes[rev]:
 					print("UR dragging (redo)!")
 					stuffed_note = note[REF]
-					add_note(false, note[NEW][0], note[NEW][1], note[NEW][2], note[NEW][3], true)
+					add_note(false, note[NEW][0], note[NEW][1], note[NEW][2], note[NEW][3])
 		3: #paste desired note(s)
 			var notes_new = Global.changes[rev][act]
 			print("URing the copypasta (replace)!")
@@ -171,6 +172,7 @@ func ur_handler():
 				clearing_notes = false
 	act = -1
 	update_note_array()
+	Global.in_ur = false
 
 
 func redraw_notes():
@@ -251,7 +253,7 @@ func _on_tmb_loaded():
 	_on_tmb_updated()
 
 
-func add_note(start_drag:bool, bar:float, length:float, pitch:float, pitch_delta:float = 0.0, never_doot:=false):
+func add_note(start_drag:bool, bar:float, length:float, pitch:float, pitch_delta:float = 0.0):
 	var note : Note
 	if act == -1: note = note_scn.instantiate()
 	else:         note = stuffed_note #Dew: don't create a new note if we're mid-U/R action; we track pre-existing notes via Global.changes when we remove them.
@@ -262,7 +264,7 @@ func add_note(start_drag:bool, bar:float, length:float, pitch:float, pitch_delta
 	note.position.x = bar_to_x(bar)
 	note.position.y = pitch_to_height(pitch)
 	note.dragging = Note.DRAG_INITIAL if start_drag else Note.DRAG_NONE
-	if doot_enabled && !never_doot: doot(pitch)
+	if doot_enabled && !Global.in_ur && !Global.pasting: doot(pitch)
 	if act == -1: add_child(note) #Dew: We don't want to re-add the child to the parent if the data was only changed via drag; it's still on-screen.
 	else: return
 	note.grab_focus()

--- a/pianoroll/chart.gd
+++ b/pianoroll/chart.gd
@@ -201,7 +201,7 @@ func _do_tmb_update():
 		if !(note is Note) || note.is_queued_for_deletion():
 			continue
 		note.position.x = note.bar * bar_spacing
-		if !note.touching_notes.has(Note.END_IS_TOUCHING): note.find_idx_in_slide()
+		if !note.touching_notes.has(Note.END_IS_TOUCHING): note.update_slide_idx()
 	queue_redraw()
 	redraw_notes()
 	_update_queued = false

--- a/pianoroll/chart.gd
+++ b/pianoroll/chart.gd
@@ -307,13 +307,11 @@ func update_note_array():
 		#print(i,": ",change)
 	print("terminal revision: ",Global.revision)
 	###
-	for note in get_children():
-		if !(note is Note) || note.is_queued_for_deletion():
-			continue
-		var note_array := [
-			note.bar, note.length, note.pitch_start, note.pitch_delta,
-			note.pitch_start + note.pitch_delta
-		]
+	for child in get_children():
+		var note := child as Note
+		if note == null || note.is_queued_for_deletion(): continue
+		
+		var note_array := note.as_array()
 		new_array.append(note_array)
 	new_array.sort_custom(func(a,b): return a[TMBInfo.NOTE_BAR] < b[TMBInfo.NOTE_BAR])
 	tmb.notes = new_array

--- a/project.godot
+++ b/project.godot
@@ -57,12 +57,12 @@ toggle_slide_prop={
 }
 toggle_snap_pitch={
 "deadzone": 0.0,
-"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":0,"key_label":69,"unicode":101,"echo":false,"script":null)
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":0,"key_label":80,"unicode":112,"echo":false,"script":null)
 ]
 }
 toggle_snap_time={
 "deadzone": 0.0,
-"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":84,"key_label":0,"unicode":116,"echo":false,"script":null)
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":0,"key_label":84,"unicode":116,"echo":false,"script":null)
 ]
 }
 hold_drag_playhead={
@@ -72,7 +72,7 @@ hold_drag_playhead={
 }
 hold_insert_taps={
 "deadzone": 0.5,
-"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":70,"key_label":0,"unicode":102,"echo":false,"script":null)
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":0,"key_label":70,"unicode":102,"echo":false,"script":null)
 ]
 }
 hold_slide_prop={
@@ -90,24 +90,9 @@ hold_snap_time={
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194326,"key_label":0,"unicode":0,"echo":false,"script":null)
 ]
 }
-mode_input={
+edit_mode={
 "deadzone": 0.5,
-"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":49,"key_label":0,"unicode":49,"echo":false,"script":null)
-]
-}
-mode_section={
-"deadzone": 0.5,
-"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":50,"key_label":0,"unicode":50,"echo":false,"script":null)
-]
-}
-mode_lyrics={
-"deadzone": 0.5,
-"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":51,"key_label":0,"unicode":51,"echo":false,"script":null)
-]
-}
-lyrics_mode={
-"deadzone": 0.5,
-"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":0,"key_label":76,"unicode":108,"echo":false,"script":null)
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":69,"key_label":0,"unicode":101,"echo":false,"script":null)
 ]
 }
 select_mode={
@@ -115,9 +100,9 @@ select_mode={
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":83,"key_label":0,"unicode":115,"echo":false,"script":null)
 ]
 }
-edit_mode={
+lyrics_mode={
 "deadzone": 0.5,
-"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":69,"key_label":0,"unicode":101,"echo":false,"script":null)
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":51,"key_label":0,"unicode":51,"echo":false,"script":null)
 ]
 }
 

--- a/section_handle.gd
+++ b/section_handle.gd
@@ -28,7 +28,8 @@ func update_pos(bar:float): position.x = %Chart.bar_to_x(bar) - 3
 
 func _gui_input(event):
 	var bar = chart.x_to_bar(event.position.x + position.x)
-	if %Settings.snap_time && self != %PlayheadHandle: bar = snapped(bar, chart.current_subdiv)
+	if %Settings.snap_time && !(self == %PlayheadHandle && !dragging):
+		bar = snapped(bar, chart.current_subdiv)
 	if event is InputEventMouseButton && event.button_index == MOUSE_BUTTON_LEFT:
 		var rect := Rect2(Vector2.ZERO, size)
 		Input.set_custom_mouse_cursor(grabbing_hand if event.pressed
@@ -36,6 +37,7 @@ func _gui_input(event):
 				else null, # thankfully hotspot does not take effect on system cursors
 				Input.CURSOR_POINTING_HAND, Vector2(9, 3))
 		dragging = event.pressed
+		if event.pressed && self == %PlayheadHandle: chart.show_preview = false 
 		if event.double_click: emit_signal("double_clicked",bar)
 	elif event is InputEventMouseMotion && dragging:
 		set_bar(bar)

--- a/settings.gd
+++ b/settings.gd
@@ -3,18 +3,18 @@ extends PanelContainer
 
 var tmb : TMBInfo:
 	get: return Global.working_tmb
-@onready var title		= %SongInfo.get_node("Title")
-@onready var short_name = %SongInfo.get_node("ShortTitle")
-@onready var author 	= %SongInfo.get_node("Author")
-@onready var genre		= %SongInfo.get_node("Genre")
-@onready var desc		= %SongInfo.get_node("Description")
-@onready var track_ref  = %SongInfo.get_node("TrackRef")
-@onready var length  = %SongInfo2.get_node("Length")
-@onready var tempo	 = %SongInfo2.get_node("Tempo")
-@onready var timesig = %SongInfo2.get_node("TimeSig")
-@onready var year	 = %SongInfo2.get_node("Year")
-@onready var diff	 = %SongInfo2.get_node("Diff")
-@onready var notespc = %SongInfo2.get_node("NoteSpacing")
+@onready var title		:TextField= %SongInfo.get_node("Title")
+@onready var short_name :TextField= %SongInfo.get_node("ShortTitle")
+@onready var author 	:TextField= %SongInfo.get_node("Author")
+@onready var genre		:TextField= %SongInfo.get_node("Genre")
+@onready var desc		:TextField= %SongInfo.get_node("Description")
+@onready var track_ref  :TextField= %SongInfo.get_node("TrackRef")
+@onready var length  :NumField= %SongInfo2.get_node("Length")
+@onready var tempo	 :NumField= %SongInfo2.get_node("Tempo")
+@onready var timesig :NumField= %SongInfo2.get_node("TimeSig")
+@onready var year	 :NumField= %SongInfo2.get_node("Year")
+@onready var diff	 :NumField= %SongInfo2.get_node("Diff")
+@onready var notespc :NumField= %SongInfo2.get_node("NoteSpacing")
 
 var values : Array:
 	get: return [
@@ -118,6 +118,7 @@ func _update_values():
 	track_ref.value = tmb.trackRef
 	
 	length.value = tmb.endpoint
+	length.min_value = 2
 	tempo.value = tmb.tempo
 	timesig.value = tmb.timesig
 	year.value = tmb.year
@@ -243,3 +244,7 @@ func _on_time_snap_toggled(_button_pressed):
 		false:
 			%SectionStart.step = 0.0001
 			%SectionLength.step = 0.0001
+
+
+func _on_length_value_changed(_v) -> void:
+	length.min_value = max(2,ceilf(tmb.get_last_note_off()))

--- a/settings.gd
+++ b/settings.gd
@@ -168,10 +168,12 @@ func _on_zoom_level_changed(value:float):
 # _on_zoom_level_changed is called automatically when reset is pressed
 func _on_zoom_reset_pressed(): %ZoomLevel.value = 1
 
+
 func _update_handles():
 		%SectStartHandle.update_pos(section_start)
 		%SectEndHandle.update_pos(min(section_length + section_start,tmb.endpoint))
 		%PlayheadHandle.update_pos(playhead_pos)
+
 
 func _force_decimals(box:SpinBox):
 	var lineedit = box.get_line_edit()
@@ -181,6 +183,10 @@ func _force_decimals(box:SpinBox):
 	else:
 		box.tooltip_text = str(box.value)
 		lineedit.text = ("%.4f" % box.value).rstrip('0.')
+
+
+func ensure_valid_endpoint() -> void:
+	length.min_value = max(2,ceilf(tmb.get_last_note_off()))
 
 #region Sections
 const SECT_HANDLE_RADIUS = 3.0
@@ -246,5 +252,4 @@ func _on_time_snap_toggled(_button_pressed):
 			%SectionLength.step = 0.0001
 
 
-func _on_length_gui_input(_e) -> void:
-	length.min_value = max(2,ceilf(tmb.get_last_note_off()))
+func _on_length_gui_input(_e) -> void: ensure_valid_endpoint()

--- a/tmb_info.gd
+++ b/tmb_info.gd
@@ -32,6 +32,12 @@ var timesig 	: int = 2
 var difficulty	: int = 5
 var savednotespacing : int = 120
 
+# Assumes that the notes array is sorted. It's always sorted on drag end (including note addition),
+# so this assumption should be OK, but testing against U/R may be needed.
+func get_last_note_off():
+	if notes.is_empty(): return -1
+	return notes[-1][TMBInfo.NOTE_BAR] + notes[-1][TMBInfo.NOTE_LENGTH]
+
 
 func has_note_touching_endpoint() -> bool:
 	if notes.is_empty(): return false


### PR DESCRIPTION
PR so we can collaborate properly on finishing the feature up instead of me just merging the PR and modifying it unilaterally as in the past. Not meant to be merged right away, as I do need to test more to make sure everything works properly, particularly when moving between different chart files and so on.

It's still easy to create notes that are outside of the chart's range; I thought I fixed this by preventing changing the chart end to before the last note's end -- dunno what happened to those changes, but even if I reimplement them, seeing as changing the length isn't part of the U/R history, this introduces another way that that could happen. Sure, it seems easy to catch and prevent on the user's end and it gets thrown away by Charter on save anyway but still, maybe we check the length on adding a note via U/R?

There's a lot of changes/fixes I want to make that have nothing to do with the U/R feature at all (chiefly having to do with the playhead/section/modes -- i really don't like the way they work right now), so i'll hopefully be working on those too and merging them to the feature branch from master, but it can be annoying and tedious to switch branches all the time so I might end up doing a bad thing and just include other changes on the feature branch.